### PR TITLE
creating eks node group code

### DIFF
--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -1,15 +1,15 @@
-variable "eks_version" {
-  default = "1.29"
-}
-
-variable "vpc_public_access_cidrs" {
-  default = ["0.0.0.0/0"]
-}
-
 variable "account_id" {
   default = ["985522651362"]
 }
 
 variable "region" {
   default = "ap-northeast-2"
+}
+
+variable "eks_version" {
+  default = "1.29"
+}
+
+variable "vpc_public_access_cidrs" {
+  default = ["0.0.0.0/0"]
 }

--- a/module/node/iam.tf
+++ b/module/node/iam.tf
@@ -1,0 +1,39 @@
+resource "aws_iam_instance_profile" "node_instance_profile" {
+  name = format("${var.name}-%s-%s", "node", "profile")
+  role = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_role_policy_1" {
+  role       = aws_iam_role.node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "node_role_policy_2" {
+  role       = aws_iam_role.node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_role_policy_3" {
+  role       = aws_iam_role.node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+data "aws_iam_policy_document" "policy_document" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "node_role" {
+  name               = format("${var.name}-%s-%s", "node", "role")
+  assume_role_policy = data.aws_iam_policy_document.policy_document.json
+
+  tags = {
+    Name = format("${var.name}-%s-%s", "node", "role")
+  }
+}

--- a/module/node/locals.tf
+++ b/module/node/locals.tf
@@ -1,0 +1,20 @@
+locals {
+  node_configs = [
+    {
+      name        = "monitoring"
+      node_labels = "role=monitoring"
+    },
+    {
+      name        = "general"
+      node_labels = "role=general"
+    }
+  ]
+
+  user_data = <<-EOF
+  #!/bin/bash -xe
+
+  B64_CLUSTER_CA=${var.eks_ca}
+  APISERVER_ENDPOINT=${var.apiserver_endpoint}
+  /etc/eks/bootstrap.sh ${var.eks_name} --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $APISERVER_ENDPOINT --kubelet-extra-args "--node-labels %s"
+  EOF
+}

--- a/module/node/main.tf
+++ b/module/node/main.tf
@@ -1,0 +1,73 @@
+resource "aws_launch_template" "lt" {
+  for_each = { for node in local.node_configs : node.name => node }
+
+  name_prefix            = format("${var.name}-%s-%s-%s", each.value.name, "node", "lt")
+  image_id               = data.aws_ssm_parameter.node_ami.value
+  instance_type          = var.instance_type
+  key_name               = var.key_name
+  vpc_security_group_ids = var.security_group_ids
+  user_data              = "${base64encode(format(local.user_data, each.value.node_labels))}"
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.node_instance_profile.arn
+  }
+  
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      encrypted   = var.volume_encrypted
+      kms_key_id  = var.kms_key_id
+      volume_size = var.volume_size
+      volume_type = var.volume_type
+    }
+  }
+}
+
+resource "aws_autoscaling_group" "node" {
+  for_each = { for node in local.node_configs : node.name => node }
+
+  name                 = format("${var.name}-%s-%s-%s", each.value.name, "worker", "group")
+  min_size             = var.min_size
+  max_size             = var.max_size
+  desired_capacity     = var.desired_capacity
+  vpc_zone_identifier  = var.subnet_ids
+  health_check_type    = var.health_check_type
+
+  launch_template {
+    id      = aws_launch_template.lt[each.value.name].id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = format("${var.name}-%s-%s-%s", each.value.name, "worker", "group")
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kubernetes.io/cluster/${var.eks_name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/${var.eks_name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/enabled"
+    value               = "true"
+    propagate_at_launch = true
+  }
+}
+
+data "aws_ssm_parameter" "node_ami" {
+  name = "/aws/service/eks/optimized-ami/${var.eks_version}/amazon-linux-2/recommended/image_id"
+}

--- a/module/node/variables.tf
+++ b/module/node/variables.tf
@@ -1,0 +1,89 @@
+variable "name" {
+  type    = string
+  default = ""
+}
+
+variable "security_group_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "key_name" {
+  type    = string
+  default = ""
+}
+
+variable "instance_type" {
+  type    = string
+  default = ""
+}
+
+variable "user_data" {
+  type    = string
+  default = ""
+}
+
+variable "volume_encrypted" {
+  type    = bool
+  default = true
+}
+
+variable "volume_size" {
+  type    = string
+  default = ""
+}
+
+variable "volume_type" {
+  type    = string
+  default = ""
+}
+
+variable "min_size" {
+  type    = string
+  default = ""
+}
+
+variable "max_size" {
+  type    = string
+  default = ""
+}
+
+variable "desired_capacity" {
+  type    = string
+  default = ""
+}
+
+variable "subnet_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "health_check_type" {
+  type    = string
+  default = ""
+}
+
+variable "eks_name" {
+  type    = string
+  default = ""
+}
+
+variable "eks_ca" {
+  type    = string
+  default = ""
+}
+
+variable "apiserver_endpoint" {
+  type    = string
+  default = ""
+}
+
+variable "kms_key_id" {
+  type    = string
+  default = "arn:aws:kms:ap-northeast-2:985522651362:key/9fdfae90-2be7-44dd-892d-eb6720c064fc"
+}
+
+variable "eks_version" {
+  type    = string
+  default = ""
+}

--- a/node/aws.tf
+++ b/node/aws.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  allowed_account_ids = var.account_id
+  region              = var.region
+}

--- a/node/main.tf
+++ b/node/main.tf
@@ -1,0 +1,23 @@
+module "node" {
+  source = "../module/node"
+
+  name               = var.name
+  eks_name           = data.terraform_remote_state.eks.outputs.eks_id
+  security_group_ids = [data.terraform_remote_state.sg.outputs.node_sg_id]
+  key_name           = format("${var.name}-%s", "node")
+  eks_version        = data.terraform_remote_state.eks.outputs.eks_version
+  instance_type      = var.instance_type
+
+  eks_ca             = data.terraform_remote_state.eks.outputs.eks_ca_certificate
+  apiserver_endpoint = data.terraform_remote_state.eks.outputs.eks_endpoint
+
+  volume_encrypted = true
+  volume_size      = var.volume_size
+  volume_type      = var.volume_type
+
+  min_size          = 1
+  max_size          = 5
+  desired_capacity  = 1
+  subnet_ids        = [data.terraform_remote_state.vpc.outputs.subnet_ids[0], data.terraform_remote_state.vpc.outputs.subnet_ids[1]]
+  health_check_type = var.health_check_type
+}

--- a/node/remote_backend.tf
+++ b/node/remote_backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "sangun-admin"
+
+    workspaces {
+      name = "k8s-infra-code_node"
+    }
+  }
+}

--- a/node/remote_state.tf
+++ b/node/remote_state.tf
@@ -1,0 +1,35 @@
+data "terraform_remote_state" "vpc" {
+  backend = "remote"
+
+  config = {
+    organization = "sangun-admin"
+
+    workspaces = {
+      name = "base-infra-code_network_vpc"
+    }
+  }
+}
+
+data "terraform_remote_state" "sg" {
+  backend = "remote"
+
+  config = {
+    organization = "sangun-admin"
+
+    workspaces = {
+      name = "base-infra-code_network_sg"
+    }
+  }
+}
+
+data "terraform_remote_state" "eks" {
+  backend = "remote"
+
+  config = {
+    organization = "sangun-admin"
+
+    workspaces = {
+      name = "k8s-infra-code_eks"
+    }
+  }
+}

--- a/node/variabels.tf
+++ b/node/variabels.tf
@@ -1,0 +1,27 @@
+variable "account_id" {
+  default = ["985522651362"]
+}
+
+variable "region" {
+  default = "ap-northeast-2"
+}
+
+variable "instance_type" {
+  default = "t3.small"
+}
+
+variable "volume_size" {
+  default = 6
+}
+
+variable "volume_type" {
+  default = "gp3"
+}
+
+variable "health_check_type" {
+  default = "EC2"
+}
+
+variable "name" {
+  default = "eks"
+}


### PR DESCRIPTION
- eks cluster의 node group으로 monitoring, general 사용
- 자체 관리형 노드 그룹 사용 위해 bootstrap 설정 및 lt tag kubernetes.io/cluster/ 추가
- lt 이미지는 system parameter store에서 eks 버전에 최적화된 최신 AMI 자동으로 가져오도록 설정
- cluster autoscaler 사용 위한 lt tag k8s.io/cluster-autoscaler/ 추가